### PR TITLE
Add manual workflow to update Strapi

### DIFF
--- a/.github/workflows/update-strapi.yml
+++ b/.github/workflows/update-strapi.yml
@@ -1,0 +1,37 @@
+name: Manual Update Strapi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-strapi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Update Strapi
+        run: npm install @strapi/strapi
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git checkout -b update-strapi
+          git add package.json package-lock.json
+          git commit -m "chore: update strapi"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update strapi"
+          branch: update-strapi
+          base: master
+          title: "Update Strapi"
+          body: "This PR updates Strapi using \`npm install @strapi/strapi\`."

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 strapi-cloud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 npm install
 ```
 
-For first use - make .evn file with this content : https://github.com/strapi/strapi-cloud-template-blog/blob/main/.env.example
+For first use - make a .env file with this content : https://github.com/strapi/strapi-cloud-template-blog/blob/main/.env.example
 
 Strapi comes with a full featured [Command Line Interface](https://docs.strapi.io/dev-docs/cli) (CLI) which lets you scaffold and manage your project in seconds.
 
@@ -32,6 +32,14 @@ Build your admin panel. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-
 
 ```
 npm run build
+```
+
+### `seed:example`
+
+Load the project with example data.
+
+```
+npm run seed:example
 ```
 
 ## ⚙️ Deployment


### PR DESCRIPTION
## Summary
- add workflow that installs latest `@strapi/strapi` and opens a PR to `master`
- adjust to use v4 actions and use `npm install` command

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e6c3c775c83309d439e09eb0599dd