### PR TITLE
Fix syntax error in workflow YAML

### DIFF
--- a/.github/workflows/update-strapi.yml
+++ b/.github/workflows/update-strapi.yml
@@ -34,4 +34,4 @@ jobs:
           branch: update-strapi
           base: master
           title: "Update Strapi"
-          body: "This PR updates Strapi using \`npm install @strapi/strapi\`."
+          body: "This PR updates Strapi using `npm install @strapi/strapi`."


### PR DESCRIPTION
## Summary
- fix body string in update-strapi workflow

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e7636f70c833086e9d2f08060718d