### PR TITLE
Fix PR workflow

### DIFF
--- a/.github/workflows/update-strapi.yml
+++ b/.github/workflows/update-strapi.yml
@@ -1,8 +1,6 @@
 name: Manual Update Strapi
-
 on:
   workflow_dispatch:
-
 
 jobs:
   update-strapi:

--- a/.github/workflows/update-strapi.yml
+++ b/.github/workflows/update-strapi.yml
@@ -3,9 +3,6 @@ name: Manual Update Strapi
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   update-strapi:

--- a/.github/workflows/update-strapi.yml
+++ b/.github/workflows/update-strapi.yml
@@ -31,7 +31,7 @@ jobs:
           git commit -m "chore: update strapi"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update strapi"

--- a/.github/workflows/update-strapi.yml
+++ b/.github/workflows/update-strapi.yml
@@ -3,6 +3,10 @@ name: Manual Update Strapi
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-strapi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix manual Strapi update workflow to have permissions to create pull requests

## Testing
- `npm install @strapi/strapi` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_685e833170a0833095db8315497e06ae